### PR TITLE
lib/server.js: version option exit status is normally 0;

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,7 @@ opts.parse([
 		callback: function () {
 			
 			console.log(pkg.version);
-			process.exit(1);
+			process.exit(0);
 		}
 	},
 	{


### PR DESCRIPTION
ここで `exit(1)` を返して終了するのは不自然な気がしたっ
